### PR TITLE
Move single flighted optimistic updates into user space

### DIFF
--- a/convex/getRoom.ts
+++ b/convex/getRoom.ts
@@ -20,6 +20,6 @@ export default query({
         doc.asset,
       ]),
     );
-    return { shapes, bindings, assets };
+    return { shapes, bindings, assets, mutationId: null as null | number };
   },
 });

--- a/convex/updateRoom.ts
+++ b/convex/updateRoom.ts
@@ -8,8 +8,6 @@ export default mutation({
     shapes: v.any(),
     bindings: v.any(),
     assets: v.any(),
-
-    mutationId: v.number(),
   },
   handler: async (ctx, args) => {
     const user = await ctx.auth.getUserIdentity();

--- a/convex/updateRoom.ts
+++ b/convex/updateRoom.ts
@@ -8,6 +8,8 @@ export default mutation({
     shapes: v.any(),
     bindings: v.any(),
     assets: v.any(),
+
+    mutationId: v.number(),
   },
   handler: async (ctx, args) => {
     const user = await ctx.auth.getUserIdentity();

--- a/src/multiplayer/ConvexRoomManager.ts
+++ b/src/multiplayer/ConvexRoomManager.ts
@@ -75,7 +75,7 @@ export class ConvexRoomManager {
     if (!this.inflightMutationId && this.hasBufferedMutation()) {
       const mutationId = this.nextMutationId++;
       this.inflightMutationId = mutationId;
-      const args = { mutationId, ...this.bufferedMutation };
+      const args = this.bufferedMutation;
       this.bufferedMutation = { shapes: {}, bindings: {}, assets: {} };
 
       console.log("Kicking off", mutationId, args);

--- a/src/multiplayer/ConvexRoomManager.ts
+++ b/src/multiplayer/ConvexRoomManager.ts
@@ -1,0 +1,129 @@
+import type { TldrawApp } from "@tldraw/tldraw";
+import { api } from "convex/_generated/api";
+import { ConvexReactClient } from "convex/react";
+import { RoomState, RoomDiff, mergeDiff, patchRoom } from "./util";
+
+export class ConvexRoomManager {
+  setLoading?: (loading: boolean) => void;
+  watchDispose: () => void;
+
+  currentQueryValue?: RoomState;
+
+  nextMutationId = 0;
+  inflightMutationId: number | null = null;
+  completedMutationId = 0;
+  bufferedMutation: RoomDiff = {
+    shapes: {},
+    bindings: {},
+    assets: {},
+  };
+
+  constructor(
+    private convex: ConvexReactClient,
+    private app: TldrawApp | undefined,
+    setLoading: (loading: boolean) => void,
+  ) {
+    const watch = convex.watchQuery(api.getRoom.default, {});
+    this.watchDispose = watch.onUpdate(() => {
+      const result = watch.localQueryResult();
+      if (!result) {
+        return;
+      }
+      console.log("Updated query", result);
+      if (this.setLoading) {
+        this.setLoading(false);
+        delete this.setLoading;
+      }
+      const { mutationId, ...remaining } = result;
+      if (this.inflightMutationId) {
+        if (!mutationId) {
+          console.log(`Mutation ID ${this.inflightMutationId} completed!`);
+          this.completedMutationId = this.inflightMutationId;
+          this.inflightMutationId = null;
+
+          // Kick off another mutation if needed.
+          this.submitUpdate();
+        } else {
+          if (this.inflightMutationId !== mutationId) {
+            throw new Error(
+              `Mutation ID mismatch: expected ${this.inflightMutationId}, got ${mutationId}`,
+            );
+          }
+        }
+      } else {
+        if (mutationId) {
+          throw new Error(`Unexpected inflight mutation ID ${mutationId}`);
+        }
+      }
+      this.currentQueryValue = remaining;
+      this.updateApp();
+    });
+    this.setLoading = setLoading;
+  }
+
+  submitUpdate(diff?: RoomDiff) {
+    if (!this.app) {
+      return;
+    }
+
+    // Fold in the diff into the buffered mutation.
+    if (diff) {
+      this.bufferedMutation = mergeDiff(this.bufferedMutation, diff);
+    }
+
+    // If there isn't already a mutation inflight, kick one off.
+    if (!this.inflightMutationId && this.hasBufferedMutation()) {
+      const mutationId = this.nextMutationId++;
+      this.inflightMutationId = mutationId;
+      const args = { mutationId, ...this.bufferedMutation };
+      this.bufferedMutation = { shapes: {}, bindings: {}, assets: {} };
+
+      console.log("Kicking off", mutationId, args);
+
+      const mutationPromise = this.convex.mutation(
+        api.updateRoom.default,
+        args,
+        {
+          optimisticUpdate: (localQueryStore, args) => {
+            const result = localQueryStore.getQuery(api.getRoom.default, {});
+            if (!result) {
+              console.log("No result during optimistic update");
+              return;
+            }
+            const newResult = { mutationId, ...patchRoom(result, args) };
+            localQueryStore.setQuery(api.getRoom.default, {}, newResult);
+          },
+        },
+      );
+      mutationPromise.catch((e) => {
+        console.error(`Mutation failed:`, e);
+      });
+    }
+
+    this.updateApp();
+  }
+
+  hasBufferedMutation() {
+    const { shapes, bindings, assets } = this.bufferedMutation;
+    return (
+      Object.keys(shapes).length > 0 ||
+      Object.keys(bindings).length > 0 ||
+      Object.keys(assets).length > 0
+    );
+  }
+
+  updateApp() {
+    if (!this.app || !this.currentQueryValue) {
+      return;
+    }
+    const { shapes, bindings, assets } = patchRoom(
+      this.currentQueryValue,
+      this.bufferedMutation,
+    );
+    this.app.replacePageContent(shapes, bindings, assets);
+  }
+
+  dispose() {
+    this.watchDispose();
+  }
+}

--- a/src/multiplayer/multiplayer.tsx
+++ b/src/multiplayer/multiplayer.tsx
@@ -64,7 +64,7 @@ function Logout() {
 
 function Editor({ roomId }: { roomId: string }) {
   const { error, ...events } = useMultiplayerState(roomId);
-  if (error) return <div>Error: {error.message}</div>;
+  if (error) return <div>Error: {(error as any).message}</div>;
 
   const [app, setApp] = React.useState<TldrawApp>();
   const handleMount = React.useCallback(

--- a/src/multiplayer/useMultiplayerState.ts
+++ b/src/multiplayer/useMultiplayerState.ts
@@ -5,13 +5,11 @@ import type {
   TDUser,
   TldrawApp,
 } from "@tldraw/tldraw";
-import { OptimisticLocalStore } from "convex/browser";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import useSingleFlight from "./useSingleFlight";
 import { api } from "convex/_generated/api";
-import { Watch, useConvex, useMutation, useQuery } from "convex/react";
-import { FunctionReturnType } from "convex/server";
+import { useConvex, useMutation } from "convex/react";
 import { ConvexRoomManager } from "./ConvexRoomManager";
 import { removeUndefinedFields } from "./util";
 

--- a/src/multiplayer/util.ts
+++ b/src/multiplayer/util.ts
@@ -1,0 +1,57 @@
+import type { TDAsset, TDBinding, TDShape } from "@tldraw/tldraw";
+
+export function removeUndefinedFields(obj: any) {
+  return JSON.parse(JSON.stringify(obj));
+}
+function mergeUpdates<V>(
+  a: Record<string, V | null>,
+  b: Record<string, V | null>,
+): Record<string, V | null> {
+  const out = Object.fromEntries(Object.entries(a));
+  for (const [k, v] of Object.entries(b)) {
+    out[k] = v;
+  }
+  return out;
+}
+
+export type RoomState = {
+  shapes: Record<string, TDShape>;
+  bindings: Record<string, TDBinding>;
+  assets: Record<string, TDAsset>;
+};
+
+export type RoomDiff = {
+  shapes: Record<string, TDShape | null>;
+  bindings: Record<string, TDBinding | null>;
+  assets: Record<string, TDAsset | null>;
+};
+function applyPatch<T>(
+  state: Record<string, T>,
+  patch: Record<string, T | null>,
+) {
+  const result = { ...state };
+  for (const [k, v] of Object.entries(patch)) {
+    if (v !== null) {
+      result[k] = v;
+    } else {
+      delete result[k];
+    }
+  }
+  return result;
+}
+
+export function patchRoom(state: RoomState, diff: RoomDiff): RoomState {
+  return {
+    shapes: applyPatch(state.shapes, diff.shapes),
+    bindings: applyPatch(state.bindings, diff.bindings),
+    assets: applyPatch(state.assets, diff.assets),
+  };
+}
+
+export function mergeDiff(left: RoomDiff, right: RoomDiff): RoomDiff {
+  return {
+    shapes: mergeUpdates(left.shapes, right.shapes),
+    bindings: mergeUpdates(left.bindings, right.bindings),
+    assets: mergeUpdates(left.assets, right.assets),
+  };
+}

--- a/src/multiplayer/util.ts
+++ b/src/multiplayer/util.ts
@@ -3,16 +3,6 @@ import type { TDAsset, TDBinding, TDShape } from "@tldraw/tldraw";
 export function removeUndefinedFields(obj: any) {
   return JSON.parse(JSON.stringify(obj));
 }
-function mergeUpdates<V>(
-  a: Record<string, V | null>,
-  b: Record<string, V | null>,
-): Record<string, V | null> {
-  const out = Object.fromEntries(Object.entries(a));
-  for (const [k, v] of Object.entries(b)) {
-    out[k] = v;
-  }
-  return out;
-}
 
 export type RoomState = {
   shapes: Record<string, TDShape>;
@@ -50,8 +40,8 @@ export function patchRoom(state: RoomState, diff: RoomDiff): RoomState {
 
 export function mergeDiff(left: RoomDiff, right: RoomDiff): RoomDiff {
   return {
-    shapes: mergeUpdates(left.shapes, right.shapes),
-    bindings: mergeUpdates(left.bindings, right.bindings),
-    assets: mergeUpdates(left.assets, right.assets),
+    shapes: { ...left.shapes, ...right.shapes },
+    bindings: { ...left.bindings, ...right.bindings },
+    assets: { ...left.assets, ...right.assets },
   };
 }


### PR DESCRIPTION
# Demo

https://github.com/sujayakar/tldraw-convex/assets/5784949/96b430c8-3b7e-4bc9-a51a-6fb278983a3b

# Description

We were previously reaching into the internals of our `OptimisticUpdateManager` to get optimistic updates on single flighted mutations. The issue is that when an update is buffered because there's already another mutation inflight, it can't apply an optimistic update on another query.

We get around this with a trick: In addition to having the mutation's optimistic update apply its changes to the local store, it also writes a "mutation ID" into the query's result. Then, the read side can see that a mutation ID is set and know that a mutation is inflight.

Then, when the read side observes that the mutation ID in its view of the query goes from set to unset, it can know that the mutation has completed and is fully reflected in the query set.

Finally, we compute the merge of the current query result with all buffered mutations before handing it off to TLDraw's `app` object.